### PR TITLE
Convert dictionary values to list for Python3 support

### DIFF
--- a/agent/api/dispatch/CheckPoliciesResult.py
+++ b/agent/api/dispatch/CheckPoliciesResult.py
@@ -33,7 +33,7 @@ class CheckPoliciesResult(object):
 
         has_rejections = False
         index = 0
-        roots = self.existingProjects.values() + self.newProjects.values()
+        roots = list(self.existingProjects.values()) + list(self.newProjects.values())
 
         while (not has_rejections) and (index < len(roots)):
             has_rejections = roots.pop(index).has_rejections()


### PR DESCRIPTION
In Python3 dict.values does not return list, thus not supporting operations such as "+" and "pop()".